### PR TITLE
Fix post schema.post callback signature

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function plugin(schema, options) {
         schema.post('validate', emit('validate'));
     }
     function emit(name) {
-        return function (next) {
+        return function (doc, next) {
             if (room) {
                 conn.to(room).emit(prefix + name, { id: this._id });
             }


### PR DESCRIPTION
According to docs, if the callback of the schema.post has one parameter, it is the doc. if 2, first is the doc, second is the next function. http://mongoosejs.com/docs/middleware.html